### PR TITLE
v1.1 alpha doesn't support source in volumes

### DIFF
--- a/es-client-rc.yaml
+++ b/es-client-rc.yaml
@@ -51,5 +51,4 @@ spec:
           name: storage
       volumes:
       - name: storage
-        source:
-          emptyDir: {}
+        emptyDir: {}

--- a/es-data-rc.yaml
+++ b/es-data-rc.yaml
@@ -46,5 +46,4 @@ spec:
           name: storage
       volumes:
       - name: storage
-        source:
-          emptyDir: {}
+        emptyDir: {}

--- a/es-master-rc.yaml
+++ b/es-master-rc.yaml
@@ -48,5 +48,4 @@ spec:
           name: storage
       volumes:
       - name: storage
-        source:
-          emptyDir: {}
+        emptyDir: {}


### PR DESCRIPTION
Kubernetes v1.1 alpha doesn't support source in volume.