### PR TITLE
This changes add a compatible kibana cluster to the elastic search cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,20 @@ Providing your own version of [the images automatically built from this reposito
 
 ## Test
 
-### Deploy
+### Deploy ELK (Elasticsearch and Kibana)
+./start-es-cluster.sh
+
+### Stopping the elk cluster
+./stop-es-cluster.sh
+
+### Test Kibana URL
+http://{kubernetes-node-ips}:30102/status
+
+### Test Elastic search API
+http://{kubernetes-node-ips}:30101
+
+
+### Deploy Elasticsearch Only
 
 ```
 kubectl create -f es-discovery-svc.yaml

--- a/es-svc.yaml
+++ b/es-svc.yaml
@@ -10,7 +10,9 @@ spec:
   selector:
     component: elasticsearch
     role: client
+  clusterIP: 10.0.0.110
   ports:
   - name: http
+    nodePort: 30101
     port: 9200
     protocol: TCP

--- a/kibana-svc.yaml
+++ b/kibana-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  labels:
+    component: kibana
+    role: web
+spec:
+  type: LoadBalancer
+  selector:
+    app: kibana
+    tier: frontend
+  ports:
+  - name: kibana-expose-service
+    port: 80
+    protocol: TCP
+    nodePort: 30102
+    targetPort: 5601

--- a/kibana.yaml
+++ b/kibana.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kibana
+  labels:
+    component: kibana
+    role: web
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: kibana
+        tier: frontend
+    spec:
+      containers:
+      - image: kibana:4.5
+        name: kibana
+        env:
+        - name: ELASTICSEARCH_URL
+          value: http://10.0.0.110:9200
+        - name: NODE_OPTIONS
+          value: "--max-old-space-size=300"
+        ports:
+        - containerPort: 5601
+          name: kibana
+        volumeMounts:
+        - name: kibana-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: kibana-persistent-storage

--- a/start-es-cluster.sh
+++ b/start-es-cluster.sh
@@ -1,0 +1,19 @@
+kubectl config use-context elk
+kubectl create -f es-discovery-svc.yaml
+kubectl create -f es-svc.yaml
+kubectl create -f es-master.yaml
+sleep 20
+kubectl create -f es-client.yaml
+sleep 30
+kubectl create -f es-data.yaml
+kubectl create -f kibana.yaml
+sleep 30
+kubectl create -f kibana-svc.yaml
+
+kubectl scale deployment es-master --replicas 3
+kubectl scale deployment es-client --replicas 2
+kubectl scale deployment es-data --replicas 2
+kubectl scale deployment kibana --replicas 2
+sleep 30
+kubectl get deployments,pods
+

--- a/stop-es-cluster.sh
+++ b/stop-es-cluster.sh
@@ -1,0 +1,12 @@
+kubectl config use-context elk
+kubectl delete deployment es-data --cascade
+kubectl delete deployment es-client --cascade
+kubectl delete deployment es-master --cascade
+kubectl delete deployment kibana --cascade
+kubectl delete rc --all --cascade
+kubectl delete pod --all --cascade
+kubectl delete svc --all
+kubectl get pods
+
+
+


### PR DESCRIPTION
- Adds a Kibana cluster.
- Integrates to the elastic search services. For this the elastic search service now has a cluster IP. This IP is used by Kibana to communicate with elastic search.
- Exposes two Node Ports, one for elastic search and one for kibana.
