### PR TITLE
adding curator for cleanup of indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,27 @@ You should see something similar to the following:
   "active_shards_percent_as_number" : 100.0
 }
 ```
+
+## Clean up with Curator
+
+Additionally, you can run a Scheduled Job running [Curator](https://github.com/elastic/curator) to clean up your indices (or do other actions on your ES).
+
+For this you need to deploy a Config Map (which configures the Curator) and the Scheduled Job:
+
+```
+kubectl create -f es-curator-configmap.yaml
+kubectl create -f es-curator.yaml
+```
+
+The pod is set to run once a day at 1 minute past midnight and delete indices that are older than 3 days.
+
+You can change the schedule by editing the Cron notation in the `es-curator.yaml`.
+
+You can change the action (e.g. delete older than 3 days) by editing the `es-curator-configmap.yaml`. The definition of the `action_file.yaml` is quite self-explaining for simple set ups. For more advanced configuration options, please consult the [Curator Documentation](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html).
+
+If you want to remove Curator again, just run:
+
+```
+kubectl delete scheduledjob curator
+kubectl delete configmap curator-config
+``` 

--- a/es-curator-config.yaml
+++ b/es-curator-config.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curator-config
+  namespace: logging
+data:
+  action_file.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    actions:
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: 3
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+  config.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    client:
+      hosts:
+        - elasticsearch
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']

--- a/es-curator.yaml
+++ b/es-curator.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v2alpha1
+kind: ScheduledJob
+metadata:
+  name: curator
+spec:
+  schedule: 1 0 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: curator
+            image: bobrik/curator
+            args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+            volumeMounts:
+              - name: config-volume
+                mountPath: /etc/config
+          volumes:
+            - name: config-volume
+              configMap:
+                name: curator-config
+          restartPolicy: OnFailure


### PR DESCRIPTION
Adding Curator as add-on in form of a Scheduled Job, which runs once a day and cleans up old indices. The Scheduled Job is configured through a Config Map object.