### PR TITLE
Remove Kibana service port name so that it is accessible

### DIFF
--- a/kibana-svc.yaml
+++ b/kibana-svc.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     component: kibana
   ports:
-  - name: http
-    port: 80
+  - port: 80
     targetPort: 5601
     protocol: TCP


### PR DESCRIPTION
As per #119, the `kibana-svc.yaml` file specifies a port name which prevents the service being accessed in the way the documentation suggests.

In the Kubernetes docs [here](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#manually-constructing-apiserver-proxy-urls) it says if you have a `port_name` you must include this in the URL like so:

```
http://kubernetes_master_address/api/v1/namespaces/namespace_name/services/service_name[:port_name]/proxy
```

So the simplest fix would be to remove the `port_name` and then the documentation is correct.