### PR TITLE
Adding PDB to es master and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ spec:
 
 <a id="helm">
 
+## PodDisruptionBudget
+
+If you want to ensure that more than 1 node won't be unavailable at a time, you can add PodDisruptionBudget manifests:
+```
+kubectl create -f es-master-pdb.yaml
+kubectl create -f es-data-pdb.yaml
+```
+
+Note: It's not recommended to grow this number because 1 node could be in maintenance, another fall down and you can't lose another node if the number of replicas is equal to two.
+
 ## Deploying with Helm
 
 [Helm](https://github.com/kubernetes/helm) charts for a basic (non-stateful) ElasticSearch deployment are maintained at https://github.com/clockworksoul/helm-elasticsearch. With Helm properly installed and configured, standing up a complete cluster is almost trivial:

--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ spec:
 
 ## PodDisruptionBudget
 
-If you want to ensure that more than 1 node won't be unavailable at a time, you can add PodDisruptionBudget manifests:
+If one wants to ensure that no more than `n` Elasticsearch nodes will be unavailable at a time, one can optionally (change and) apply the following manifests:
 ```
 kubectl create -f es-master-pdb.yaml
 kubectl create -f es-data-pdb.yaml
 ```
 
-Note: It's not recommended to grow this number because 1 node could be in maintenance, another fall down and you can't lose another node if the number of replicas is equal to two.
+**Note:** This is an advanced subject and one should only put it in practice if one understands clearly what it means both in the Kubernetes and Elasticsearch contexts.
 
 ## Deploying with Helm
 

--- a/es-data-pdb.yaml
+++ b/es-data-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: elasticsearch-data
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: data

--- a/es-master-pdb.yaml
+++ b/es-master-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: elasticsearch-master
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: master


### PR DESCRIPTION
With this PDB, only one pod can be unavailable (but not if we request
manually a pod delete)