### PR TITLE
Ensure cluster is in a green state before stopping a pod

### DIFF
--- a/es-data.yaml
+++ b/es-data.yaml
@@ -53,6 +53,11 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /_cluster/health?wait_for_status=green&timeout=28800s
+              port: 9300
         volumeMounts:
         - name: storage
           mountPath: /data

--- a/stateful/es-data-stateful.yaml
+++ b/stateful/es-data-stateful.yaml
@@ -49,6 +49,11 @@ spec:
           value: "false"
         - name: "ES_JAVA_OPTS"
           value: "-Xms256m -Xmx256m"
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /_cluster/health?wait_for_status=green&timeout=28800s
+              port: 9300
         ports:
         - containerPort: 9300
           name: transport


### PR DESCRIPTION
The timeout is set to 8h before releasing the hook and forcing ES node
to shutdown.