### PR TITLE
Expose the service externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ As we can assert, the cluster is up and running. Easy, wasn't it?
 
 *Don't forget* that services in Kubernetes are only acessible from containers in the cluster. For different behavior one should [configure the creation of an external load-balancer](http://kubernetes.io/v1.1/docs/user-guide/services.html#type-loadbalancer). While it's supported within this example service descriptor, its usage is out of scope of this document, for now.
 
+*Note:* if you are using one of the cloud providers which support external load balancers, setting the type field to "LoadBalancer" will provision a load balancer for your Service. You can uncomment the field in [es-svc.yaml](https://github.com/pires/kubernetes-elasticsearch-cluster/blob/master/es-svc.yaml).
 ```
 $ kubectl get svc elasticsearch
 NAME            CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE

--- a/es-svc.yaml
+++ b/es-svc.yaml
@@ -13,3 +13,4 @@ spec:
   - name: http
     port: 9200
     protocol: TCP
+#type: LoadBalancer


### PR DESCRIPTION
[LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer): Exposes the service externally using a cloud provider’s load balancer. NodePort and ClusterIP services, to which the external load balancer will route, are automatically created.