### PR TITLE
Allow loopback connections. Fixes #128

### DIFF
--- a/es-client.yaml
+++ b/es-client.yaml
@@ -49,6 +49,8 @@ spec:
           value: "true"
         - name: "ES_JAVA_OPTS"
           value: "-Xms256m -Xmx256m"
+        - name: "NETWORK_HOST"
+          value: "_site_,_lo_"
         ports:
         - containerPort: 9200
           name: http


### PR DESCRIPTION
Avoid https://github.com/pires/kubernetes-elasticsearch-cluster/issues/128  and allow port-forwarding via `kubectl port-forward es-client 9200`