### PR TITLE
stop curator from going into crashloopbackoff due to empty indicie list

### DIFF
--- a/es-curator-config.yaml
+++ b/es-curator-config.yaml
@@ -19,6 +19,7 @@ data:
           timeout_override:
           continue_if_exception: False
           disable_action: False
+          ignore_empty_list: True
         filters:
         - filtertype: age
           source: name


### PR DESCRIPTION
I have noticed that with the current config of 3 days, in an initial setup you will get two conjobs failing because of an empty list, this should fix that by ignoring an empty list being returned, in the case of there not being indicies older than 3 days. 

Log Message below

"ERROR     Unable to complete action "delete_indices".  No actionable items in list: <class 'curator.exceptions.NoIndices'>"