### PR TITLE
Set `PROCESSORS` accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ One can change this in the deployment descriptors available in this repository.
 
 * The [stateful](stateful) directory contains an example which deploys the data pods as a `StatefulSet`. These use a `volumeClaimTemplates` to provision persistent storage for each pod.
 
+* By default, `PROCESSORS` is set to `1`. This may not be enough for some deployments, especially at startup time. Adjust `resources.limits.cpu` and/or `livenessProbe` accordingly if required. Note that `resources.limits.cpu` must be an integer.
+
 <a id="pre-requisites">
 
 ## Pre-requisites

--- a/es-client.yaml
+++ b/es-client.yaml
@@ -46,6 +46,10 @@ spec:
           value: -Xms256m -Xmx256m
         - name: NETWORK_HOST
           value: _site_,_lo_
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         ports:
         - containerPort: 9200
           name: http

--- a/es-client.yaml
+++ b/es-client.yaml
@@ -50,6 +50,9 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
         ports:
         - containerPort: 9200
           name: http

--- a/es-data.yaml
+++ b/es-data.yaml
@@ -44,6 +44,13 @@ spec:
           value: "false"
         - name: ES_JAVA_OPTS
           value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
         ports:
         - containerPort: 9300
           name: transport

--- a/es-master.yaml
+++ b/es-master.yaml
@@ -48,6 +48,10 @@ spec:
           value: "false"
         - name: ES_JAVA_OPTS
           value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         ports:
         - containerPort: 9300
           name: transport

--- a/es-master.yaml
+++ b/es-master.yaml
@@ -52,6 +52,9 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
         ports:
         - containerPort: 9300
           name: transport

--- a/stateful/es-data-stateful.yaml
+++ b/stateful/es-data-stateful.yaml
@@ -45,6 +45,13 @@ spec:
           value: "false"
         - name: ES_JAVA_OPTS
           value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          limits:
+            cpu: 1
         ports:
         - containerPort: 9300
           name: transport


### PR DESCRIPTION
This change will set `PROCESSORS` to the actual number of available CPUs
to the Container, allowing ES to properly adjust thread pool sizes.

This is the companion change to https://github.com/pires/docker-elasticsearch-kubernetes/pull/57