### PR TITLE
Update Kibana to use upstream OSS image 6.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,17 +318,9 @@ Various parameters of the cluster, including replica count and memory allocation
 
 **ATTENTION**: This is community supported so it most probably is out-of-date.
 
-Additionally, one can also add Kibana to the mix. In order to do so, one must use a container image of Kibana without x-pack,
-as it's not supported by the Elasticsearch container images used in this repository.
+Additionally, one can also add Kibana to the mix. In order to do so, one can use the Elastic upstream open source docker image without x-pack.
 
-An image is already provided but one can build their own like follows:
-
-```
-FROM docker.elastic.co/kibana/kibana:5.5.1
-RUN bin/kibana-plugin remove x-pack
-```
-
-If ones does provide their own image, one must make sure to alter the following files before deploying:
+### Deploy
 
 ```
 kubectl create -f kibana.yaml

--- a/kibana.yaml
+++ b/kibana.yaml
@@ -16,20 +16,12 @@ spec:
     spec:
       containers:
       - name: kibana
-        image: cfontes/kibana-xpack-less:5.5.0
+        image: docker.elastic.co/kibana/kibana-oss:6.1.2
         env:
         - name: CLUSTER_NAME
           value: myesdb
         - name: SERVER_BASEPATH
           value: /api/v1/proxy/namespaces/default/services/kibana
-        - name: XPACK_SECURITY_ENABLED
-          value: 'false'
-        - name: XPACK_GRAPH_ENABLED
-          value: 'false'
-        - name: XPACK_ML_ENABLED
-          value: 'false'
-        - name: XPACK_REPORTING_ENABLED
-          value: 'false'
         resources:
           limits:
             cpu: 1000m


### PR DESCRIPTION
Includes README.md update as requested in #166 

Note: I have tested it with NodePort by also setting kibana.yaml SERVER_BASEPATH value to "". 

Fixes #166 