### PR TITLE
Update README to reflect env vars for 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ The default value for this environment variable is 2, meaning a cluster will nee
 
 
 ### How can I customize `elasticsearch.yaml`?
-Read a different config file by settings env var `path.conf=/path/to/my/config/`. Another option would be to build one's own image from  [this repository](https://github.com/pires/docker-elasticsearch-kubernetes)
+Read a different config file by settings env var `ES_PATH_CONF=/path/to/my/config/` [(see the Elasticsearch docs for more)](https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#config-files-location). Another option would be to build one's own image from  [this repository](https://github.com/pires/docker-elasticsearch-kubernetes)
 
 ## Troubleshooting
 


### PR DESCRIPTION
The old `path.conf` environment variable has been changed to `ES_PATH_CONF`.