### PR TITLE
fix kibana server basepath when using apiserver proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Kibana will be available through service `kibana`, and one will be able to acces
 proxy it through the Kubernetes API Server, as follows:
 
 ```
-https://<API_SERVER_URL>/api/v1/proxy/namespaces/default/services/kibana/proxy
+https://<API_SERVER_URL>/api/v1/namespaces/default/services/kibana:http/proxy
 ```
 
 One can also create an Ingress to expose the service publicly or simply use the service nodeport.

--- a/kibana.yaml
+++ b/kibana.yaml
@@ -21,7 +21,7 @@ spec:
         - name: CLUSTER_NAME
           value: myesdb
         - name: SERVER_BASEPATH
-          value: /api/v1/proxy/namespaces/default/services/kibana
+          value: /api/v1/namespaces/default/services/kibana:http/proxy
         resources:
           limits:
             cpu: 1000m


### PR DESCRIPTION
apiserver proxy now uses
api/v1/proxy/namespaces/namespace_name/services/service_name[:port_name]