### PR TITLE
Define master service as headless

### DIFF
--- a/es-discovery-svc.yaml
+++ b/es-discovery-svc.yaml
@@ -13,3 +13,4 @@ spec:
   - name: transport
     port: 9300
     protocol: TCP
+  clusterIP: None


### PR DESCRIPTION
Regarding https://github.com/pires/kubernetes-elasticsearch-cluster/issues/69 `elasticsearch-discovery` should be headless service.

cc @pires @topikachu 

Documentation of headless services:
https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services