### PR TITLE
Stateful masters #2

### DIFF
--- a/stateful/README.md
+++ b/stateful/README.md
@@ -4,7 +4,7 @@ This directory contains Kubernetes configurations which run elasticsearch data a
 
 ## Storage
 
-The [`es-data-stateful.yaml`](es-data-stateful.yaml) and [`es-master-stateful.yaml`](es-master-stateful.yaml) files contain `volumeClaimTemplates` sections which request a 12 GB (2 GB for master pods) disks. This is plenty of space for a demonstration cluster, but will fill up quickly under moderate to heavy load. Consider modifying the disk size to your needs.
+The [`es-data-stateful.yaml`](es-data-stateful.yaml) and [`es-master-stateful.yaml`](es-master-stateful.yaml) files contain `volumeClaimTemplates` sections which request 2GB volume for each master node, and 12GB volume for each data node. This is plenty of space for a demonstration cluster, but will fill up quickly under moderate to heavy load. Consider modifying the disk size to your needs.
 
 ## Deploy
 The root directory contains instructions for deploying elasticsearch using a `Deployment` with transient storage for data pods. These brief instructions show a deployment using the `StatefulSet` and `StorageClass`.

--- a/stateful/README.md
+++ b/stateful/README.md
@@ -12,6 +12,8 @@ The root directory contains instructions for deploying elasticsearch using a `De
 ```
 kubectl create -f ../es-discovery-svc.yaml
 kubectl create -f ../es-svc.yaml
+
+kubectl create -f es-master-svc.yaml
 kubectl create -f es-master-stateful.yaml
 kubectl rollout status -f es-master-stateful.yaml
 
@@ -19,6 +21,7 @@ kubectl create -f ../es-ingest-svc.yaml
 kubectl create -f ../es-ingest.yaml
 kubectl rollout status -f ../es-ingest.yaml
 
+kubectl create -f es-data-svc.yaml
 kubectl create -f es-data-stateful.yaml
 kubectl rollout status -f es-data-stateful.yaml
 ```

--- a/stateful/README.md
+++ b/stateful/README.md
@@ -1,10 +1,10 @@
 # Elasticsearch StatefulSet Data Pod
 
-This directory contains Kubernetes configurations which run elasticsearch data pods as a [`StatefulSet`](https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/), using storage provisioned using a [`StorageClass`](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html). Be sure to read and understand the documentation in the root directory, which deploys the data pods as a `Deployment` using an `emptyDir` for storage.
+This directory contains Kubernetes configurations which run elasticsearch data and master pods as a [`StatefulSet`](https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/), using storage provisioned using a [`StorageClass`](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html). Be sure to read and understand the documentation in the root directory, which deploys the data pods as a `Deployment` using an `emptyDir` for storage.
 
 ## Storage
 
-The [`es-data-stateful.yaml`](es-data-stateful.yaml) file contains a `volumeClaimTemplates` section which requests a 12 GB disk. This is plenty of space for a demonstration cluster, but will fill up quickly under moderate to heavy load. Consider modifying the disk size to your needs.
+The [`es-data-stateful.yaml`](es-data-stateful.yaml) and [`es-master-stateful.yaml`](es-master-stateful.yaml) files contain `volumeClaimTemplates` sections which request a 12 GB (2 GB for master pods) disks. This is plenty of space for a demonstration cluster, but will fill up quickly under moderate to heavy load. Consider modifying the disk size to your needs.
 
 ## Deploy
 The root directory contains instructions for deploying elasticsearch using a `Deployment` with transient storage for data pods. These brief instructions show a deployment using the `StatefulSet` and `StorageClass`.
@@ -12,8 +12,8 @@ The root directory contains instructions for deploying elasticsearch using a `De
 ```
 kubectl create -f ../es-discovery-svc.yaml
 kubectl create -f ../es-svc.yaml
-kubectl create -f ../es-master.yaml
-kubectl rollout status -f ../es-master.yaml
+kubectl create -f es-master-stateful.yaml
+kubectl rollout status -f es-master-stateful.yaml
 
 kubectl create -f ../es-ingest-svc.yaml
 kubectl create -f ../es-ingest.yaml

--- a/stateful/es-data-stateful.yaml
+++ b/stateful/es-data-stateful.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: es-data

--- a/stateful/es-master-stateful.yaml
+++ b/stateful/es-master-stateful.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: es-master

--- a/stateful/es-master-stateful.yaml
+++ b/stateful/es-master-stateful.yaml
@@ -6,6 +6,7 @@ metadata:
     component: elasticsearch
     role: master
 spec:
+  serviceName: elasticsearch-master
   replicas: 3
   template:
     metadata:

--- a/stateful/es-master-stateful.yaml
+++ b/stateful/es-master-stateful.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: es-master
+  labels:
+    component: elasticsearch
+    role: master
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        component: elasticsearch
+        role: master
+    spec:
+      initContainers:
+      - name: init-sysctl
+        image: busybox:1.27.2
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      containers:
+      - name: es-master
+        image: quay.io/pires/docker-elasticsearch-kubernetes:6.3.0
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CLUSTER_NAME
+          value: myesdb
+        - name: NUMBER_OF_MASTERS
+          value: "2"
+        - name: NODE_MASTER
+          value: "true"
+        - name: NODE_INGEST
+          value: "false"
+        - name: NODE_DATA
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: -Xms256m -Xmx256m
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        resources:
+          requests:
+            cpu: 0.25
+          limits:
+            cpu: 1
+        ports:
+        - containerPort: 9300
+          name: transport
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+    spec:
+      storageClassName: standard
+      accessModes: [ ReadWriteOnce ]
+      resources:
+        requests:
+          storage: 2Gi

--- a/stateful/es-master-svc.yaml
+++ b/stateful/es-master-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-master
+  labels:
+    component: elasticsearch
+    role: master
+spec:
+  ports:
+  - port: 9300
+    name: transport
+  clusterIP: None
+  selector:
+    component: elasticsearch
+    role: master


### PR DESCRIPTION
Hey Paulo! @pires 

After merging stateful masters branch, you removed services for StatefulSets which I think are still needed for the network to work properly. These services are referenced via spec.serviceName in StatefulSet Controller.

Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations 
"StatefulSets currently require a Headless Service to be responsible for the network identity of the Pods. You are responsible for creating this Service."

I've added es-data-svc.yaml and es-master-svc.yaml as a part of stateful cluster deployment.

Sorry for forgetting it in the first PR