### PR TITLE
Stateful app version v1 fix

### DIFF
--- a/stateful/es-data-stateful.yaml
+++ b/stateful/es-data-stateful.yaml
@@ -6,6 +6,10 @@ metadata:
     component: elasticsearch
     role: data
 spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: data
   serviceName: elasticsearch-data
   replicas: 3
   template:

--- a/stateful/es-data-svc.yaml
+++ b/stateful/es-data-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-data
+  labels:
+    component: elasticsearch
+    role: data
+spec:
+  ports:
+  - port: 9300
+    name: transport
+  clusterIP: None
+  selector:
+    component: elasticsearch
+    role: data

--- a/stateful/es-master-stateful.yaml
+++ b/stateful/es-master-stateful.yaml
@@ -6,6 +6,10 @@ metadata:
     component: elasticsearch
     role: master
 spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: master
   serviceName: elasticsearch-master
   replicas: 3
   template:


### PR DESCRIPTION
Hey Paulo!

Here's another fix, thanks @paulavijit [ it should fix #220 ]

Since app/v1 StatefulSet Controller needs spec.selector to match template.metadata.labels
Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

The fix includes headless service referenced in es-data-stateful.yaml as spec.serviceName and selector fixes for master-stateful and data-stateful.

Kind Regards!